### PR TITLE
Change value for --security-opt label= for TCP

### DIFF
--- a/mariadb-tcp@.service
+++ b/mariadb-tcp@.service
@@ -19,6 +19,7 @@ ExecStart=/usr/bin/podman run \
   --name mariadb-tcp-%i \
   --detach \
   --volume %h/mariadb-data-tcp.%i:/var/lib/mysql:Z \
+  --security-opt label=disable \
   --network none \
   --userns=keep-id \
   --env MARIADB_USER=example-user \


### PR DESCRIPTION
* Although container-selinux v2.179.0
  https://github.com/containers/container-selinux/releases/tag/v2.179.0
  seems to support socket activation via Podman,
  the release is quite new (2022-02-21) which
  means it has not yet arrived in the common
  Linux distributions. Let's use
  --security-opt label=disable
  for the moment being. This can be changed
  at a later point.

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>